### PR TITLE
Moved the resolveHandler method to a seperate class HandlerResolver. 

### DIFF
--- a/src/Phroute/HandlerResolver.php
+++ b/src/Phroute/HandlerResolver.php
@@ -1,0 +1,22 @@
+<?php
+namespace Phroute;
+
+class HandlerResolver implements HandlerResolverInterface {
+	
+	/**
+	 * Create an instance of the given handler.
+	 *
+	 * @param $handler
+	 * @return array
+	 */
+	
+	public function resolve ($handler)
+	{
+		if(is_array($handler) and is_string($handler[0]))
+		{
+			$handler[0] = new $handler[0];
+		}
+		
+		return $handler;
+	}
+}

--- a/src/Phroute/HandlerResolverInterface.php
+++ b/src/Phroute/HandlerResolverInterface.php
@@ -1,0 +1,14 @@
+<?php
+namespace Phroute;
+
+interface HandlerResolverInterface {
+	
+	/**
+	 * Create an instance of the given handler.
+	 *
+	 * @param $handler
+	 * @return array
+	 */
+	
+	public function resolve($handler);
+} 


### PR DESCRIPTION
The Dispatch class now depends on the HandlerResolverInterface. This allows to people to implement their own resolvers. Basically this allows to use Phroute more easily with a IoC Container.

@joegreen0991: I do not know what this does to the performance. Apart that 2 new files need to be included I cannot see why this would hurt. The second option would be to make resolveHandler a protected method. This allows the method to be overwritten. My feeling is however that resolving the handler is a seperate responsibility and therefore should live in its own class.
