### PR TITLE
Skip controller params that are part of the route

### DIFF
--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -284,7 +284,7 @@ class RouteCollector implements RouteDataProviderInterface {
                 {
                     $methodName = $this->camelCaseToDashed(substr($method->name, strlen($valid)));
 
-                    $params = $this->buildControllerParameters($method);
+                    $params = $this->buildControllerParameters($method, $route);
 
                     if($methodName === self::DEFAULT_CONTROLLER_ROUTE)
                     {
@@ -305,12 +305,16 @@ class RouteCollector implements RouteDataProviderInterface {
      * @param ReflectionMethod $method
      * @return string
      */
-    private function buildControllerParameters(ReflectionMethod $method)
+    private function buildControllerParameters(ReflectionMethod $method, $route)
     {
         $params = '';
 
         foreach($method->getParameters() as $param)
         {
+            if (strpos($route, '{' . $param->getName()) !== false)
+            {
+                continue;
+            }
             $params .= "/{" . $param->getName() . "}" . ($param->isOptional() ? '?' : '');
         }
 


### PR DESCRIPTION
We have the following route.
```php
$this->controller(['/directdebit/{companyId:i}/{yearId:i}', 'directdebit'], DirectDebitController::class);
```

But the following fails due to Cannot use the same placeholder companyId twice.

```php
public function getTransferDelete ($companyId, $yearId, $id) {
```

The companyId and yearId parameter should be skipped when generating a route for a controller because they are part of the route itself.