### PR TITLE
Added PATCH support

### DIFF
--- a/src/Phroute/Route.php
+++ b/src/Phroute/Route.php
@@ -22,6 +22,8 @@ class Route {
 
     const PUT = 'PUT';
 
+    const PATCH = 'PATCH';
+
     const DELETE = 'DELETE';
 
     const OPTIONS = 'OPTIONS';

--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -235,6 +235,17 @@ class RouteCollector implements RouteDataProviderInterface {
      * @param array $filters
      * @return RouteCollector
      */
+    public function patch($route, $handler, array $filters = [])
+    {
+        return $this->addRoute(Route::PATCH, $route, $handler, $filters);
+    }
+
+    /**
+     * @param $route
+     * @param $handler
+     * @param array $filters
+     * @return RouteCollector
+     */
     public function delete($route, $handler, array $filters = [])
     {
         return $this->addRoute(Route::DELETE, $route, $handler, $filters);
@@ -336,6 +347,7 @@ class RouteCollector implements RouteDataProviderInterface {
             Route::GET,
             Route::POST,
             Route::PUT,
+            Route::PATCH,
             Route::DELETE,
             Route::HEAD,
             Route::OPTIONS,

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -39,6 +39,11 @@ class Test {
         return 'testRoutePutTest';
     }
 
+    public function patchTest()
+    {
+        return 'testRoutePatchTest';
+    }
+
     public function deleteTest()
     {
         return 'testRouteDeleteTest';
@@ -361,6 +366,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
             Route::GET,
             Route::POST,
             Route::PUT,
+            Route::PATCH,
             Route::DELETE,
             Route::HEAD,
             Route::OPTIONS,
@@ -378,6 +384,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('yes', $this->dispatch($r, Route::GET, 'user'));
         $this->assertEquals('yes', $this->dispatch($r, Route::DELETE, 'user'));
         $this->assertEquals('yes', $this->dispatch($r, Route::PUT, 'user'));
+        $this->assertEquals('yes', $this->dispatch($r, Route::PATCH, 'user'));
         $this->assertEquals('yes', $this->dispatch($r, Route::POST, 'user'));
         $this->assertEquals('yes', $this->dispatch($r, Route::OPTIONS, 'user'));
         $this->assertEquals('yes', $this->dispatch($r, 'MADE_UP_NON_STANDARD_METHOD', 'user'));
@@ -400,11 +407,13 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::GET, 'user'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::POST, 'user'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::PUT, 'user'));
+        $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::PATCH, 'user'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::DELETE, 'user'));
 
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::GET, 'user/index'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::POST, 'user/index'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::PUT, 'user/index'));
+        $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::PATCH, 'user/index'));
         $this->assertEquals('testRouteAnyIndex', $this->dispatch($r, Route::DELETE, 'user/index'));
 
         $this->assertEquals('hyphenated', $this->dispatch($r, Route::GET, 'user/camel-case-hyphenated'));


### PR DESCRIPTION
Added the missing HTTP Patch method, which is more convenient for APIs.

The problem is well defined in RFC 5789:

>  A new method is necessary to improve interoperability and prevent
>   errors.  The PUT method is already defined to overwrite a resource
>   with a complete new body, and cannot be reused to do partial changes.
>   Otherwise, proxies and caches, and even clients and servers, may get
>   confused as to the result of the operation.  POST is already used but
>   without broad interoperability (for one, there is no standard way to
>   discover patch format support).

 Reference [RFC 5789 - PATCH Method for HTTP](http://tools.ietf.org/html/rfc5789#section-1)