### PR TITLE
Group prefix

### DIFF
--- a/src/Phroute/Route.php
+++ b/src/Phroute/Route.php
@@ -9,6 +9,8 @@ class Route {
 
     const AFTER = 'after';
 
+    const PREFIX = 'prefix';
+
     /**
      * Constants for common HTTP methods
      */

--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -164,20 +164,22 @@ class RouteCollector implements RouteDataProviderInterface {
         $this->regexToRoutesMap[$regex][$httpMethod] = [$handler, $filters, $variables];
     }
 
+    /**
+     * @param $option string
+     * @param $instance $this
+     */
     private function processPrefixedRoutes($option, $instance)
     {
         list($prefix, $routeData)=$this->routeParser->parse(trim($option, '/'));
         $prefix = $prefix[0];
 
         foreach ($instance->reverse as $name => $entries) {
-            $flip = array_reverse($entries);
-
-            foreach (array_reverse($routeData) as $data) {
-                array_push($flip, ['variable' => false, 'value' => '/']);
-                array_push($flip, $data);
+            $flip = [$routeData[0],  ['variable' => false, 'value' => '/']];
+            foreach ($entries as $entry) {
+                $flip[] = $entry;
             }
 
-            $this->reverse[$name] = array_reverse($flip);
+            $this->reverse[$name] = $flip;
         }
 
 

--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -193,7 +193,7 @@ class RouteCollector implements RouteDataProviderInterface {
                 $this->staticRoutes[$prefix . $pattern] = $entry;
             }
         } else {
-            throw new BadRouteException('Bad prefix: "%s", should not variables.');
+            throw new BadRouteException(sprintf('Bad prefix: "%s", should not contain variables.', $prefix));
         }
     }
     /**

--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -187,7 +187,7 @@ class RouteCollector implements RouteDataProviderInterface {
 
             if ($prefix === trim($options['prefix'], '/')) {
                 foreach ($self->regexToRoutesMap as $pattern => $entry) {
-                    $this->regexToRoutesMap[$prefix . $pattern] = $entry;
+                    $this->regexToRoutesMap[$prefix . '/' . $pattern] = $entry;
                 }
 
                 foreach ($self->staticRoutes as $pattern => $entry) {

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -180,7 +180,8 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 
         $r->any( array('product-catalogue/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
         $this->assertEquals('product-catalogue/store', $r->route('products'));
-        $this->assertEquals('product-catalogue/store/1', $r->route('products', array(1)));    }
+        $this->assertEquals('product-catalogue/store/1', $r->route('products', array(1)));
+    }
 
     public function testGroupsReverseRoutes()
     {

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -178,11 +178,9 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
     {
         $r = $this->router();
 
-        $r->any( array('products/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
-
-        $this->assertEquals('products/store', $r->route('products'));
-        $this->assertEquals('products/store/1', $r->route('products', array(1)));
-    }
+        $r->any( array('product-catalogue/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
+        $this->assertEquals('product-catalogue/store', $r->route('products'));
+        $this->assertEquals('product-catalogue/store/1', $r->route('products', array(1)));    }
 
     public function testGroupsReverseRoutes()
     {

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -179,6 +179,7 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $r = $this->router();
 
         $r->any( array('product-catalogue/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
+
         $this->assertEquals('product-catalogue/store', $r->route('products'));
         $this->assertEquals('product-catalogue/store/1', $r->route('products', array(1)));
     }

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -178,10 +178,22 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
     {
         $r = $this->router();
 
-        $r->any( array('product-catalogue/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
+        $r->any( array('products/store/{store:i}?', 'products'), array(__NAMESPACE__.'\\Test','route'));
 
-        $this->assertEquals('product-catalogue/store', $r->route('products'));
-        $this->assertEquals('product-catalogue/store/1', $r->route('products', array(1)));
+        $this->assertEquals('products/store', $r->route('products'));
+        $this->assertEquals('products/store/1', $r->route('products', array(1)));
+    }
+
+    public function testPrefixGroupsReverseRoutes()
+    {
+        $r = $this->router();
+
+        $r->group([], function($r) {
+            $r->any(['/{store:i}', 'products'], array(__NAMESPACE__.'\\Test','route'));
+        }, ['prefix' => 'product-catalogue/store/items']);
+
+        #$this->assertEquals('product-catalogue/store/items', $r->route('products'));
+        $this->assertEquals('product-catalogue/store/items/1', $r->route('products', array(1)));
     }
 
     /**
@@ -357,6 +369,50 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(2, $dispatchedFilter);
         $this->assertEquals(1, $dispatchedFilter2);
         
+    }
+
+    public function testPrefixedFilterGroups()
+    {
+        $r = $this->router();
+
+        $dispatchedFilter = 0;
+        $dispatchedFilter2 = 0;
+
+        $r->filter('test', function() use(&$dispatchedFilter){
+            $dispatchedFilter++;
+        });
+
+        $r->filter('test2', function() use(&$dispatchedFilter2){
+            $dispatchedFilter2++;
+        });
+
+        $r->group(array('before' => 'test'), function($router){
+            $router->addRoute('GET', '/', function() {
+
+            });
+            $router->group(array('before' => 'test2'), function($router){
+                $router->addRoute('GET', '/{id}', function() {
+
+                });
+            });
+        }, ['prefix' => '/user']);
+
+        $this->dispatch($r, 'GET', '/user');
+
+        $this->assertEquals(1, $dispatchedFilter);
+
+        $this->dispatch($r, 'GET', '/user/2');
+
+        $this->assertEquals(2, $dispatchedFilter);
+        $this->assertEquals(1, $dispatchedFilter2);
+    }
+
+    public function testVariablePrefix()
+    {
+        $this->setExpectedException('\Phroute\Phroute\Exception\BadRouteException');
+
+        $r = $this->router();
+        $r->group([], function(){}, ['prefix' => '/demo/{unexpected}']);
     }
 
     public function testValidMethods()

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -184,15 +184,27 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('products/store/1', $r->route('products', array(1)));
     }
 
+    public function testGroupsReverseRoutes()
+    {
+        $r = $this->router();
+
+        $r->group([], function($r) {
+            $r->any(['products/store/{store:i}?', 'products'], array(__NAMESPACE__.'\\Test','route'));
+        });
+
+        $this->assertEquals('products/store', $r->route('products'));
+        $this->assertEquals('products/store/1', $r->route('products', array(1)));
+    }
+
     public function testPrefixGroupsReverseRoutes()
     {
         $r = $this->router();
 
         $r->group([], function($r) {
-            $r->any(['/{store:i}', 'products'], array(__NAMESPACE__.'\\Test','route'));
-        }, ['prefix' => 'product-catalogue/store/items']);
+            $r->any(['items/{store:i}?', 'products'], array(__NAMESPACE__.'\\Test','route'));
+        }, ['prefix' => 'product-catalogue/store']);
 
-        #$this->assertEquals('product-catalogue/store/items', $r->route('products'));
+        $this->assertEquals('product-catalogue/store/items', $r->route('products'));
         $this->assertEquals('product-catalogue/store/items/1', $r->route('products', array(1)));
     }
 


### PR DESCRIPTION
#22 - improvements to keep inline with current style of defining options.

Allow variables in route prefixes - the original threw an BadRouteException but I can't see why this should not be allowed.

Allow nested prefix groups