### PR TITLE
Support checking for named routes (RouteCollector::hasRoute($name))

### DIFF
--- a/src/Phroute/RouteCollector.php
+++ b/src/Phroute/RouteCollector.php
@@ -61,6 +61,14 @@ class RouteCollector implements RouteDataProviderInterface {
 
     /**
      * @param $name
+     * @return bool
+     */
+	public function hasRoute($name) {
+		return isset($this->reverse[$name]);
+	}
+
+    /**
+     * @param $name
      * @param array $args
      * @return string
      */

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -162,6 +162,10 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         $r->addRoute('GET', array('/foo/{name}/{something:i}', 'name2'), array(__NAMESPACE__.'\\Test','route'));
                 
         $this->assertEquals('foo/joe/something',$r->route('name2', ['joe', 'something']));
+
+
+        $this->assertTrue($r->hasRoute('name2'));
+        $this->assertFalse($r->hasRoute('unknown-name'));
     }
 
     public function testOptionalReverseRoute()


### PR DESCRIPTION
There's no way to check whether a named route exists. If called with an unknown route name, RouteCollector::route(…) produces a notice and a warning.

This PR adds a method hasRoute($name).