### PR TITLE
Add support for named parameter handler resolving.

### DIFF
--- a/src/Phroute/Dispatcher.php
+++ b/src/Phroute/Dispatcher.php
@@ -54,8 +54,12 @@ class Dispatcher {
         }
         
         $resolvedHandler = $this->handlerResolver->resolve($handler);
-        
-        $response = call_user_func_array($resolvedHandler, $vars);
+
+        if ($this->handlerResolver instanceof NamedParameterHandlerResolverInterface) {
+            $response = call_user_func($resolvedHandler, $vars);
+        } else {
+            $response = call_user_func_array($resolvedHandler, $vars);
+        }
 
         return $this->dispatchFilters($afterFilter, $response);
     }

--- a/src/Phroute/NamedParameterHandlerResolverInterface.php
+++ b/src/Phroute/NamedParameterHandlerResolverInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phroute\Phroute;
+
+interface NamedParameterHandlerResolverInterface extends HandlerResolverInterface
+{
+}

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -601,6 +601,53 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
         
         $this->assertEquals($methods, array_keys($data->getStaticRoutes()['user']));
     }
+
+    public function testParameterHandler()
+    {
+        $handler = $this
+            ->getMockBuilder('\Phroute\Phroute\HandlerResolverInterface')
+            ->getMock();
+
+        $handler
+            ->method('resolve')
+            ->willReturnCallback(function () {
+                $handler = function($name, $country) {
+                    return [$name, $country];
+                };
+
+                return $handler;
+            });
+
+        $r = $this->router();
+        $r->get('/{name}/{country}', function (){});
+
+        $response = (new Dispatcher($r->getData(), $handler))->dispatch('GET', '/joe/uk');
+        $this->assertSame(['joe', 'uk'], $response);
+    }
+
+    public function testNamedParameterHandler()
+    {
+        $handler = $this
+            ->getMockBuilder('\Phroute\Phroute\NamedParameterHandlerResolverInterface')
+            ->getMock();
+
+        $handler
+            ->method('resolve')
+            ->willReturnCallback(function () {
+                $handler = function($args) {
+                    return $args;
+                };
+
+                return $handler;
+            });
+
+        $r = $this->router();
+        $r->get('/{name}/{country}', function (){});
+
+        $response = (new Dispatcher($r->getData(), $handler))->dispatch('GET', '/joe/uk');
+
+        $this->assertSame(['name' => 'joe', 'country' => 'uk'], $response);
+    }
     
     public function provideFoundDispatchCases()
     {


### PR DESCRIPTION
Hello,

This PR adds support for Handler Resolvers that would prefer to receive an associative array where `name => value` for parameters.

I am using [PHP DI](http://php-di.org/index.html) for dependency injection which is able to inject parameters by matching the name.  Passing an associative array of arguments means I can write a handler resolver like this:

``` PHP
class RouteHandlerResolver implements NamedParameterHandlerResolverInterface
{
    //...
    public function resolve($handler)
    {
        if (is_array($handler) && is_string($handler[0])) {
            $handler[0] = $this->container->get($handler[0]);
        }

        $handler = function ($args) use ($handler) {
            return $this->container->call($handler, $args);
        };

        return $handler;
    }
}
```

Which allows using routes like this:

``` PHP
$router->get('/hello/{name}', function (Request $request, Response $response, $name) {
    $response->setContent("hello {$name}!");
    return $response;
});
```

I wrote a separate interface to allow adding this behavior without causing any backwards compatibility breaks.  You can simply implement the regular `HandlerResolverInterface` if you do not want a single array of named parameters.

Let me know if this is something you would be interested in adding to the library.

Thanks!
