### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
 
 before_script:
   - composer install --dev

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
          }
     },
   "require": {
-    "php": ">=5.4.0"
+    "php": ">=5.6.0"
   },
   "require-dev": {
     "satooshi/php-coveralls": "^1.0",
-    "phpunit/phpunit": "^5.0"
+    "phpunit/phpunit": "^5.0|^6.5"
   }
 }

--- a/test/Dispatcher/DispatcherTest.php
+++ b/test/Dispatcher/DispatcherTest.php
@@ -6,6 +6,7 @@ use Phroute\Phroute\RouteCollector;
 use Phroute\Phroute\RouteParser;
 use Phroute\Phroute\Dispatcher;
 use Phroute\Phroute\Route;
+use PHPUnit\Framework\TestCase;
 
 class Test {
     
@@ -90,7 +91,7 @@ class Test {
     }
 }
 
-class DispatcherTest extends \PHPUnit_Framework_TestCase {
+class DispatcherTest extends TestCase {
 
     /**
      * Set appropriate options for the specific Dispatcher class we're testing
@@ -130,11 +131,11 @@ class DispatcherTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * @dataProvider provideMethodNotAllowedDispatchCases
+     * @expectedException Phroute\Phroute\Exception\HttpMethodNotAllowedException
+     * @expectedExceptionMessage Allow: GET
      */
     public function testMethodNotAllowedDispatches($method, $uri, $callback, $allowed)
     {
-        $this->setExpectedException('\Phroute\Phroute\Exception\HttpMethodNotAllowedException',"Allow: " . implode(', ', $allowed));
-
         $r = $this->router();
         $callback($r);
         $this->dispatch($r, $method, $uri);


### PR DESCRIPTION
# Changed log
- Set multiple PHPUnit version to support multiple PHP versions tests.
- Use the class-based PHPUnit namespace and expected exception annotation to be compatible with the stable PHPUnit version.
- Add ```php-7.2``` test in Travis build.
- According to the PHPUnit version in ```require-dev```, it set the ```5.0``` and it supports the ```php-5.6+```. I set the PHP version ```>=5.6``` in ```require``` .